### PR TITLE
Allow sending connection options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,12 @@ already has ``local_capacity - 1`` messages in memory. Higher settings
 accelerate throughput a little bit; lower settings help adhere to
 ``local_capacity`` more rigorously.
 
+``connection_options``
+~~~~~~~~~~~~~~~~~~
+
+A dictionary of values that will be passed as kwargs when aioamqp attempts
+to connect to the RabbitMQ server.
+
 Design decisions
 ----------------
 

--- a/channels_rabbitmq/connection.py
+++ b/channels_rabbitmq/connection.py
@@ -334,7 +334,8 @@ class Connection:
         remote_capacity=100,
         prefetch_count=10,
         expiry=60,
-        group_expiry=86400
+        group_expiry=86400,
+        connection_options={},
     ):
         self.loop = loop
         self.host = host
@@ -344,6 +345,7 @@ class Connection:
         self.expiry = expiry
         self.group_expiry = group_expiry
         self.queue_name = queue_name
+        self.connection_options = connection_options
 
         # incoming_messages: await `get()` on any channel-name queue to receive
         # the next message. If the `get()` is canceled, that's probably because
@@ -435,7 +437,8 @@ class Connection:
         self._is_connected = False
 
         logger.info("Channels connecting to RabbitMQ at %s", self.host)
-        transport, protocol = await aioamqp.from_url(self.host)
+        transport, protocol = await aioamqp.from_url(self.host,
+                                                     **self.connection_options)
 
         logger.debug("Connected; setting up")
         channel = await protocol.channel()

--- a/channels_rabbitmq/connection.py
+++ b/channels_rabbitmq/connection.py
@@ -437,8 +437,9 @@ class Connection:
         self._is_connected = False
 
         logger.info("Channels connecting to RabbitMQ at %s", self.host)
-        transport, protocol = await aioamqp.from_url(self.host,
-                                                     **self.connection_options)
+        transport, protocol = await aioamqp.from_url(
+            self.host, **self.connection_options
+        )
 
         logger.debug("Connected; setting up")
         channel = await protocol.channel()

--- a/channels_rabbitmq/core.py
+++ b/channels_rabbitmq/core.py
@@ -50,13 +50,15 @@ class RabbitmqChannelLayer(BaseChannelLayer):
         prefetch_count=10,
         expiry=60,
         group_expiry=86400,
+        connection_options={},
     ):
         self.host = host
         self.local_capacity = local_capacity
         self.remote_capacity = remote_capacity
         self.prefetch_count = prefetch_count
         self.expiry = expiry
-        self.group_expiry = 86400
+        self.group_expiry = group_expiry
+        self.connection_options = connection_options
 
         # In inefficient client code (e.g., async_to_sync()), there may be
         # several send() or receive() calls within different event loops --
@@ -88,6 +90,7 @@ class RabbitmqChannelLayer(BaseChannelLayer):
             prefetch_count=self.prefetch_count,
             expiry=self.expiry,
             group_expiry=self.group_expiry,
+            connection_options=self.connection_options,
         )
         self._connections[loop] = connection  # assume lock is held
 


### PR DESCRIPTION
This will allow sending kwargs to aioamqp like `verify_ssl` when using a self-signed certificate.

Also fixes a small issue where changing the value of `group_expiry` is ignored.