### PR TITLE
Use Python 3.5 compatable syntax

### DIFF
--- a/channels_rabbitmq/connection.py
+++ b/channels_rabbitmq/connection.py
@@ -334,7 +334,7 @@ class Connection:
         remote_capacity=100,
         prefetch_count=10,
         expiry=60,
-        group_expiry=86400,
+        group_expiry=86400
     ):
         self.loop = loop
         self.host = host

--- a/channels_rabbitmq/core.py
+++ b/channels_rabbitmq/core.py
@@ -77,7 +77,7 @@ class RabbitmqChannelLayer(BaseChannelLayer):
         # Choose queue name here: that way we can declare it on RabbitMQ with
         # exclusive=True and have it survive reconnections.
         rand = "".join(random.choice(string.ascii_letters) for i in range(12))
-        queue_name = f"channels_{rand}"
+        queue_name = "channels_{rand}".format(rand=rand)
 
         connection = Connection(
             loop,


### PR DESCRIPTION
With these two changes to syntax, I have been running `cahnnels_rabbitmq` on Python 3.5.3 (the latest version in Raspbian repositories) without any problems. Even if this old version is not officially supported, would it be possible to make the syntax compatible? Unfortunately, I have not been able to make the tests pass as Python 3.5 does not support the async generators used in [test_connection.py](https://github.com/CJWorkbench/channels_rabbitmq/blob/07fbcb994d57c846179155a1c29302412393a5e1/tests/test_connection.py#L17).