### PR TITLE
Change constraint of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ setup(
     include_package_data=True,
     install_requires=[
         "aioamqp~=0.13.0",
-        "asgiref~=3.1.2",
+        "asgiref~=3.1",
         "msgpack~=0.6.1",
-        "channels~=2.2.0",
+        "channels~=2.2",
     ],
     tests_require=["pytest~=3.6.0", "pytest-asyncio~=0.8", "pytest-timeout~=1.3.3"],
 )


### PR DESCRIPTION
Currently I get a dep conflict with library which depends on asgiref>=3.2,<4.0. So I updated the asgiref dep and changed the constraints to >= to avoid future conflicts. This introduces the possibility of a breaking change caused by upstream, but I see no better way to handle this. For example both Django and Flask have quite relaxed constraints on their dependencies.