### PR TITLE
1.3.0: fix pipenv install issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "channels_rabbitmq"
-version = "0.0.0"
+version = "v1.3.0"
 description = "RabbitMQ-based ASGI channel layer implementation"
 authors = ["Adam Hooper <adam@adamhooper.com>"]
 license = "BSD"


### PR DESCRIPTION
Fix a issue when doing a pipenv install:
`ERROR: Requested channels_rabbitmq from https://files.pythonhosted.org/packages/b9/6b/89a2cc6aebe044a7f21555e9b145763e93ccf820eee8f7ed6590a8fd953a/channels_rabbitmq-1.3.0.tar.gz#sha256=47e40535b6796e1a15cd525114becd9591d3fee443e55eaa1ebe25d0c0161a9d (from -r /tmp/pipenv-7jp83zw5-requirements/pipenv-1yj4f2yd-requirement.txt (line 1)) has different version in metadata: '0.0.0'
â Installation Failed`
